### PR TITLE
feat: add docker image ci workflow for releases

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# Git
+.git
+.github
+.gitignore
+
+# Python
+.venv
+__pycache__
+*.pyc
+
+# Docker
+Dockerfile.*
+docker-compose.yaml
+
+# Documentation
+README.md
+LICENSE
+Makefile
+
+# Streamlit
+.streamlit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.fastapi
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta_fastapi.outputs.tags }}
           labels: ${{ steps.meta_fastapi.outputs.labels }}
@@ -63,6 +64,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.streamlit
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta_streamlit.outputs.tags }}
           labels: ${{ steps.meta_streamlit.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,10 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository_owner }}/opamp-server-py/fastapi
+          tags: |
+            type=raw,value=latest
+            type=sha
+            type=semver,pattern={{version}}
 
       - name: Build and push fastapi
         uses: docker/build-push-action@v6
@@ -58,6 +62,10 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository_owner }}/opamp-server-py/streamlit
+          tags: |
+            type=raw,value=latest
+            type=sha
+            type=semver,pattern={{version}}
 
       - name: Build and push streamlit
         uses: docker/build-push-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,30 +30,39 @@ jobs:
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
 
-      - uses: docker/login-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/metadata-action@v5
-        id: meta
-        env:
-          # https://docs.docker.com/build/ci/github-actions/annotations/#configure-annotation-level
-          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+      - name: Docker meta for fastapi
+        id: meta_fastapi
+        uses: docker/metadata-action@v5
         with:
-          images: |
-            ghcr.io/${{ github.repository }}
-          tags: |
-            type=raw,value=latest,enable=${{ github.event_name == 'push' }}
-            type=sha,format=short,enable=${{ github.event_name == 'push' }}
+          images: ghcr.io/${{ github.repository_owner }}/opamp-server-py/fastapi
 
-      - uses: docker/build-push-action@v6
+      - name: Build and push fastapi
+        uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64
+          context: .
+          file: ./Dockerfile.fastapi
           push: true
-          sbom: true
-          provenance: mode=max
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          annotations: ${{ steps.meta.outputs.annotations }}
+          tags: ${{ steps.meta_fastapi.outputs.tags }}
+          labels: ${{ steps.meta_fastapi.outputs.labels }}
+
+      - name: Docker meta for streamlit
+        id: meta_streamlit
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/opamp-server-py/streamlit
+
+      - name: Build and push streamlit
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.streamlit
+          push: true
+          tags: ${{ steps.meta_streamlit.outputs.tags }}
+          labels: ${{ steps.meta_streamlit.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+# This action pushes new amd64 and arm64 docker images to the Docker and GitHub
+# registries on every new release of the project.
+#
+# Cobbled together from these sources:
+# - https://github.com/docker/build-push-action/#usage
+# - https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
+
+name: release
+
+on:
+  push:
+    branches: [main]
+
+  # uncomment this to enablle building for pull requests, to debug this
+  # workflow.
+  #
+  # pull_request:
+  #   branches: [main]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v5
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        env:
+          # https://docs.docker.com/build/ci/github-actions/annotations/#configure-annotation-level
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.event_name == 'push' }}
+            type=sha,format=short,enable=${{ github.event_name == 'push' }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          sbom: true
+          provenance: mode=max
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}

--- a/Dockerfile.fastapi
+++ b/Dockerfile.fastapi
@@ -1,0 +1,17 @@
+# Use an official Python runtime as a parent image
+FROM python:3.9-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the dependencies file to the working directory
+COPY requirements.txt .
+
+# Install any needed packages specified in requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the content of the local src directory to the working directory
+COPY . .
+
+# Specify the command to run on container start
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "4320"]

--- a/Dockerfile.streamlit
+++ b/Dockerfile.streamlit
@@ -1,0 +1,17 @@
+# Use an official Python runtime as a parent image
+FROM python:3.9-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the dependencies file to the working directory
+COPY requirements.txt .
+
+# Install any needed packages specified in requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the content of the local src directory to the working directory
+COPY . .
+
+# Specify the command to run on container start
+CMD ["streamlit", "run", "streamlit_app.py", "--server.port", "8502", "--server.address", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The UI is built using [Streamlit](https://streamlit.io).
 There are currently 3 pages:
 
 * `/` = The root path (eg. `http://127.0.0.1:8501/` offers an overview of the server and connected agents)
-  
+
 ![homepage page image](assets/homepage.png)
 
 * `/agents` = Offers a deeper overview of all connected agents
@@ -75,7 +75,7 @@ streamlit run streamlit_app.py --server.address 127.0.0.1 --server.port 8501
 ## Sample Collector Config
 An agent (eg. collector) needs to be configured to connect to the server. [A sample configuration file is provided](https://github.com/agardnerIT/opamp-server-py/blob/new_ui/collector/config.yaml).
 
-Download the contrib distribution binary (it has the [opamp extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/opampextension)) into the root of this folder. 
+Download the contrib distribution binary (it has the [opamp extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/opampextension)) into the root of this folder.
 
 ```
 ./otelcol-contrib --config=collector/config.yaml
@@ -84,6 +84,22 @@ Download the contrib distribution binary (it has the [opamp extension](https://g
 Go to `http://localhost:8501` and see the agent overview.
 
 Go to `http://localhost:8501/agents` to see deeper info about each agent.
+
+## Running with Docker
+
+Alternatively, you can run the server and UI using Docker.
+
+```shell
+docker-compose up -d
+```
+
+This will start the server on port 4320 and the UI on port 8501.
+
+Then run the collector as normal.
+
+```shell
+./otelcol-contrib --config=collector/config.yaml
+```
 
 ## Background Information on OpAMP
 

--- a/README.md
+++ b/README.md
@@ -14,14 +14,21 @@ This app will show you:
   - Which components are **actually** in use (running the contrib collector with lots of unused components and wondering which you can remove to slim down?)
 - Prometheus compatible endpoint at `/metrics`
 
+## Docker Images
+
+The server and UI are available as Docker images from the GitHub container registry:
+
+- [ghcr.io/agardnerIT/opamp-server-py/streamlit:latest](https://github.com/agardnerIT/opamp-server-py/pkgs/container/opamp-server-py%2Fstreamlit)
+- [ghcr.io/agardnerIT/opamp-server-py/fastapi:latest](https://github.com/agardnerIT/opamp-server-py/pkgs/container/opamp-server-py%2Fstreamlit)
+
 ## Server
 
 The server listens on the standard port of 4320.
 
 The server offers the following endpoints:
 
-* `/v1/opamp` = Agents (eg. OpenTelemetry collectors) are configured to send data to this endpoint
-* `/metrics` = Prometheus endpoint for server metrics
+- `/v1/opamp` = Agents (eg. OpenTelemetry collectors) are configured to send data to this endpoint
+- `/metrics` = Prometheus endpoint for server metrics
 
 Start the server with:
 
@@ -36,15 +43,15 @@ The UI is built using [Streamlit](https://streamlit.io).
 
 There are currently 3 pages:
 
-* `/` = The root path (eg. `http://127.0.0.1:8501/` offers an overview of the server and connected agents)
+- `/` = The root path (eg. `http://127.0.0.1:8501/` offers an overview of the server and connected agents)
 
 ![homepage page image](assets/homepage.png)
 
-* `/agents` = Offers a deeper overview of all connected agents
+- `/agents` = Offers a deeper overview of all connected agents
 
 ![agents page image](assets/agents.png)
 
-* `/agent?id=<agent-id>` = Offers a full overview of a single connected agent
+- `/agent?id=<agent-id>` = Offers a full overview of a single connected agent
 
 ![single agent page](assets/agent.png)
 
@@ -52,7 +59,7 @@ There are currently 3 pages:
 
 The UI will default to looking for a server at `localhost:4320` using `http` but these can all be adjusted using the following environment variables:
 
-```
+```shell
 export SERVER_HTTP_SCHEME="http"     # or https
 export SERVER_ADDRESS="localhost"
 export SERVER_PORT=4320
@@ -62,7 +69,7 @@ export SERVER_PORT=4320
 
 Start the server with:
 
-```
+```shell
 streamlit run streamlit_app.py --server.address 127.0.0.1 --server.port 8501
 ```
 
@@ -73,33 +80,18 @@ streamlit run streamlit_app.py --server.address 127.0.0.1 --server.port 8501
 ![agent currently effective configuration](assets/agent-currently-effective-config.png)
 
 ## Sample Collector Config
+
 An agent (eg. collector) needs to be configured to connect to the server. [A sample configuration file is provided](https://github.com/agardnerIT/opamp-server-py/blob/new_ui/collector/config.yaml).
 
 Download the contrib distribution binary (it has the [opamp extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/opampextension)) into the root of this folder.
 
-```
+```shell
 ./otelcol-contrib --config=collector/config.yaml
 ```
 
 Go to `http://localhost:8501` and see the agent overview.
 
 Go to `http://localhost:8501/agents` to see deeper info about each agent.
-
-## Running with Docker
-
-Alternatively, you can run the server and UI using Docker.
-
-```shell
-docker-compose up -d
-```
-
-This will start the server on port 4320 and the UI on port 8501.
-
-Then run the collector as normal.
-
-```shell
-./otelcol-contrib --config=collector/config.yaml
-```
 
 ## Background Information on OpAMP
 


### PR DESCRIPTION
Updated the GitHub Actions workflow to build and push Docker images on release events.

Resolved #16 